### PR TITLE
Fix peak NPS being inaccurate

### DIFF
--- a/Modules/Chart.GetNPS.lua
+++ b/Modules/Chart.GetNPS.lua
@@ -20,7 +20,7 @@ return function(Steps)
 
         for k,v in pairs( GAMESTATE:GetCurrentSong():GetNoteData(chartint) ) do
             if TD:GetElapsedTimeFromBeat(v[1]) > mMargin then
-				-- Don't round NPS values, they are not restricted to whole numbers.
+                -- Don't round NPS values, they are not restricted to whole numbers.
                 measureNPS = mDuration == 0 and 0 or measureNotes/mDuration
                 PeakNPS = (measureNPS > PeakNPS) and measureNPS or PeakNPS
                 if(measureNotes >= 15) then

--- a/Modules/Chart.GetNPS.lua
+++ b/Modules/Chart.GetNPS.lua
@@ -20,9 +20,9 @@ return function(Steps)
 
         for k,v in pairs( GAMESTATE:GetCurrentSong():GetNoteData(chartint) ) do
             if TD:GetElapsedTimeFromBeat(v[1]) > mMargin then
-                local originalval = mDuration == 0 and 0 or measureNotes/mDuration
-                measureNPS = math.round(originalval)
-                PeakNPS = (measureNPS > PeakNPS or originalval > PeakNPS) and originalval or PeakNPS
+				-- Don't round NPS values, they are not restricted to whole numbers.
+                measureNPS = mDuration == 0 and 0 or measureNotes/mDuration
+                PeakNPS = (measureNPS > PeakNPS) and measureNPS or PeakNPS
                 if(measureNotes >= 15) then
                     streamMeasures[#streamMeasures+1] = measureCount+1
                 end


### PR DESCRIPTION
NPS values aren't integers all the time, so this pull request eliminates the rounding done to it and in result fixes issues such as the NPS diagram/graph peaking above its determined height.